### PR TITLE
Bug: Delete Items From Cart

### DIFF
--- a/components/order/detail.js
+++ b/components/order/detail.js
@@ -13,7 +13,7 @@ export default function CartDetail({ cart, removeProduct }) {
               <td>{lineitem.product.name}</td>
               <td>{lineitem.product.price}</td>
               <td>
-                <span className="icon is-clickable" onClick={() => removeProduct(product.id)}>
+                <span className="icon is-clickable" onClick={() => removeProduct(lineitem.id)}>
                   <i className="fas fa-trash"></i>
                 </span>
               </td>

--- a/data/auth.js
+++ b/data/auth.js
@@ -21,7 +21,7 @@ export function register(user) {
 }
 
 export function getUserProfile() {
-  return fetchWithResponse('my-profile', {
+  return fetchWithResponse('profile', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
     }

--- a/data/products.js
+++ b/data/products.js
@@ -41,8 +41,8 @@ export function addProductToOrder(product_id) {
   })
 }
 
-export function removeProductFromOrder(id) {
-  return fetchWithoutResponse(`products/${id}/remove-from-order`, {
+export function removeProductFromOrder(product_id) {
+  return fetchWithoutResponse(`lineitems/${product_id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`


### PR DESCRIPTION
After realizing that the user couldn't delete the item in the browser, I updated the logic to ensure the front end worked with the backend. While doing so, I realized that the application was deleting line items based off their product Id which was inappropriate because there may be two items in the cart that have the same product Id (two of the same item in the cart). As a result, I changed the logic in that the item would be deleted based off the lineitemId instead.

## Changes

-updated fetch calls to utilize appropriate URL requests based off backend routes for deleting items from cart.
-updated function that deletes a lineitem from the cart to delete an item based off the lineitemId instead of the productId
-updating fetch calls for user profile to reflect URL request on backend routes.

## Requests / Responses

**Request**

DELETE `/lineitem/n` Deletes product from cart based off lineitem Id

**Response**

HTTP/1.1 200 OK, no response body


## Testing

Description of how to test code...

IN BROWSER
- [ ] Running both API and Client - log into Bangazon
- [ ] Go to products and add several items to the cart.
- [ ] Go to the cart and attempt to delete an item using the trash can icon.
- [ ] Page should refresh and the deleted item should be gone.

