### PR TITLE
BUG: client unable submit order

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -17,12 +17,12 @@ export function getOrders() {
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+  return fetchWithResponse(`orders/${orderId}`, {
     method: 'PUT',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({paymentTypeId})
+    body: JSON.stringify({ payment_type: paymentTypeId })
   })
 }


### PR DESCRIPTION
Problem: A user is unable to submit an order.


## Changes

- Updated JSON response in fetch call function to include key for payment_type (for backend to use).


## Request/Response

- n/a for front end (back end was already completed)


## Testing

-[] Log into Bangazon with a client that has a payment type
-[] Add some items to your cart
-[] Navigate to cart if you're not there
-[] Click to Complete Order
-[] select payment method, then submit order
-[] user should be directed back to "my-orders" where a list of past orders is present (this page still needs work)