### PR TITLE
Feature: users can favorite store

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -11,7 +11,7 @@ export function StoreCard({ store, width= "is-half" }) {
         </header>
         <div className="card-content">
           <p className="content">
-            Owner: {store.seller.first_name} {store.seller.last_name}
+            Owner: {store.seller.user?.first_name} {store.seller.user?.last_name}
           </p>
           <div className="content">
             {store.description}


### PR DESCRIPTION
Ticket #22

Given the user is authenticated
When the client performs a POST operation to the /products/n/like URL
Then that preference should be created for the current user

Given the user is authenticated
When the client performs a DELETE operation to the /products/n/like URL
Then that preference should be removed for the current user

Given the user is authenticated
When the client performs a GET operation to the /products/liked URL
Then the response should contain a list of products liked by the user

All likes should be displayed in the user profile

## Changes

Updated property values in "StoreCard.js" so that both profile.js and index.js could prop drill into the card.

##Testing

Head to bangazon and make sure your API is running and you are serving your front end. Click on "stores" at the top and make sure all stores populate. There should be 4. Head to your profile and see if your favorite stores are there. Note, make sure you are logged in as someone who has favorited a store or else nothing will show up.