### PR TITLE
Feature: Users can create a store in order to sell items

### DIFF
--- a/components/store/form.js
+++ b/components/store/form.js
@@ -12,7 +12,7 @@ export default function StoreForm({ nameEl, descriptionEl, saveEvent, title, rou
           type="text"
           placeholder="Store Name"
         />
-        <textarea placeholder="Add a Description..." className="textarea" ref={descriptionEl}></textarea>
+        <textarea id ="description" placeholder="Add a Description..." className="textarea" ref={descriptionEl}></textarea>
       </>
       <>
         <a className="card-footer-item" onClick={saveEvent}>Save</a>

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -8,7 +8,7 @@ const checkError = (res) => {
 }
 
 const checkErrorJson = (res) => {
-  if (res.status !== 200) {
+  if (res.status !== 200 && res.status !== 201) {
     throw Error(res.status);
   } else {
     return res.json()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1809,13 +1809,23 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "version": "1.0.30001641",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz",
+      "integrity": "sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -6721,9 +6731,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg=="
+      "version": "1.0.30001641",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz",
+      "integrity": "sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA=="
     },
     "chalk": {
       "version": "2.4.2",

--- a/pages/stores/new.js
+++ b/pages/stores/new.js
@@ -21,10 +21,11 @@ export default function NewStore() {
       setProfile({
         ...profile,
         store: res
-      })
-      router.push(`/stores/${res.id}`)
-    })
-  }
+      });
+      router.push(`/stores/${res.id}`);
+    });
+  };
+  
 
   return (
     <StoreForm nameEl={nameEl} descriptionEl={descriptionEl} saveEvent={saveStore} router={router} title="Create your store">


### PR DESCRIPTION
Description of PR that completes issue here...
Feature: Users can create a store in order to sell items
Ticket #16

## Changes

Changed checkErrorJson function in data/fetcher to allow for response code 201 as well as 200.

Recommended in the future to add other codes that are not error codes, as this function is intended to check for errors, but currently only allows for 200 and 201 responses. 

## Testing

Description of how to test code...

On client side, with API running, 
When the Interested in selling? option is chosen
Then the user should see a form to create a store with a text field for store name, and a textarea for store description

The user should be able to fill out the field and be brought to a new page for the user's store. If the user is currently existing, the page will load the already existing store for the user instead. 